### PR TITLE
modified setBorderHighlight( ) function 

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -89,10 +89,15 @@ const setBorderHighlight = (stateEl) => {
     if (stateEl.style.strokeWidth === '' || stateEl.style.strokeWidth === '0') {
         stateEl.style.stroke = '#d3d3d3';
         stateEl.style.strokeWidth = '3';
-    } else {
+               
+    } else if (stateEl.style.strokeWidth === '3') {
         stateEl.style.stroke = 'transparent';
         stateEl.style.strokeWidth = '0';
     }
+    // else {
+    //     stateEl.style.stroke = 'transparent';
+    //     stateEl.style.strokeWidth = '0';
+    // }
 }
 
 // highlights alaska state shape when page loads


### PR DESCRIPTION
There is a problem with the states being highlighted prematurely right after the page loads when the mouse cursor happens to be over a state. It doesn't appear to happen all the time. I think this is because no explicit condition was specified when when the function acts on states without the highlight (to make them highlighted).